### PR TITLE
Make sure we trim user name before submitting

### DIFF
--- a/lib/CPAN/Uploader/Tiny.pm6
+++ b/lib/CPAN/Uploader/Tiny.pm6
@@ -20,7 +20,7 @@ submethod BUILD(:$!url, :$!user, :$!password, :$!agent) {
 
 method new-from-config($file) {
     my %config = self!read-config($file);
-    self.new(user => %config<user>, password => %config<password>);
+    self.new(user => %config<user>.trim, password => %config<password>);
 }
 
 method !read-config($file) {


### PR DESCRIPTION
Apparently PAUSE doesn't like user names that have trailing spaces.  Somehow, my .pause file had a trailing space after my user name.  This was never a problem with the other uploaders I've used.  But with `mi6 upload` it made PAUSE choke (internal server error).  So add a .trim to make sure that there's no whitespace around the user name.