### PR TITLE
Add CPAN5 tag to META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -17,7 +17,7 @@
   },
   "resources" : [ ],
   "source-url" : "git://github.com/skaji/perl6-CPAN-Uploader-Tiny.git",
-  "tags" : [ ],
+  "tags" : [ "CPAN5" ],
   "test-depends" : [ ],
   "version" : "0.0.5"
 }


### PR DESCRIPTION
This module also appears to be a straight port from Perl 5, so the tag appears appropriate.